### PR TITLE
Handle pytest collection exit code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,8 @@ jobs:
       - name: Python tests
         if: ${{ hashFiles('tests/**') != '' }}
         run: |
-          pytest -q
-          status=$?
+          status=0
+          pytest -q || status=$?
           if [ "$status" -eq 5 ]; then
             echo "No tests collected; skipping."
             exit 0


### PR DESCRIPTION
## Summary
- replace the Python tests step with a shell script that special-cases pytest exit code 5

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d32f31ee8c832fa91ce54da8fffb7e