### PR TITLE
Update pyproject dependency installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,9 @@ jobs:
         run: python -m pip install -r requirements.txt
       - name: Python deps (pyproject)
         if: ${{ hashFiles('pyproject.toml') != '' && hashFiles('requirements.txt') == '' }}
-        run: python -m pip install build pytest
+        run: |
+          python -m pip install ".[test]" || python -m pip install .
+          python -m pip install pytest
       - name: Python tests
         if: ${{ hashFiles('tests/**') != '' }}
         run: pytest -q || echo "No pytest configured; skipping."


### PR DESCRIPTION
## Summary
- install the project itself when a pyproject.toml is present instead of pulling build
- ensure pytest remains available for the test step

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d331f2f0b4832f84f9827bdaf0bece