### PR TITLE
feat: modernize reusable CI workflow

### DIFF
--- a/.github/docs/reusable-ci.md
+++ b/.github/docs/reusable-ci.md
@@ -26,6 +26,19 @@
 3. **codeql** – optional; initializes, autobuilds, analyzes with languages from `prepare` (defaults to Python when no stack detected).
 4. **sbom** – optional; uses Syft to produce `sbom.json` (CycloneDX) and uploads as artifact.
 
+### Prepare job outputs
+
+Downstream jobs consume a handful of signals emitted by the `prepare` job. They are available to callers as `needs.prepare.outputs.*` when overriding the workflow:
+
+| Output | Description |
+| ------ | ----------- |
+| `has_python` / `has_node` / `has_rust` | Language footprints detected in the repository or via the `language` hint. |
+| `python_version` / `node_version` | Resolved toolchain versions, honoring provided inputs and defaulting to Python 3.12 / Node LTS. |
+| `codeql_languages` | Comma-delimited list of languages passed to CodeQL (defaults to `python` when nothing is detected). |
+| `codeql_enabled` | Whether CodeQL analysis will run after applying feature toggles. |
+| `run_tests_enabled` | Indicates if test steps—including the Make fallback—should execute. |
+| `sbom_enabled` | Signals if the SBOM job should run and upload an artifact. |
+
 ## Caller Example
 
 ```yaml

--- a/.github/docs/reusable-ci.md
+++ b/.github/docs/reusable-ci.md
@@ -54,5 +54,6 @@ jobs:
 - Python support tests for `requirements.txt`, `pyproject.toml`, or `poetry.lock` before bootstrapping.
 - Node support caches `npm` installs and gracefully skips lint/test when scripts are missing.
 - Rust support assumes a standard Cargo layout and enforces `cargo fmt --check` before running tests.
+- CodeQL skips unsupported Rust analysis: Rust-only repos automatically disable CodeQL, while mixed-language projects filter the Rust footprint from the language list.
 - Make fallback (`make test` → `make ci`) only runs when no supported language footprint is detected and tests are enabled.
 - SBOM upload only publishes for workflow calls and tag/release events to keep noise low during PR edits.

--- a/.github/docs/reusable-ci.md
+++ b/.github/docs/reusable-ci.md
@@ -52,6 +52,7 @@ jobs:
 - The reusable workflow also triggers on pushes/PRs within this repo so edits can be validated locally.
 - Direct pushes/PRs in this repo run with defaults (`language=none`, `run_tests=true`, `codeql=true`, `sbom=false`) so the workflow remains executable without workflow-call inputs.
 - Python support tests for `requirements.txt`, `pyproject.toml`, or `poetry.lock` before bootstrapping.
+- Python and Node setup steps honor the `python-version`/`node-version` inputs when provided and fall back to `3.12`/`lts/*` for in-repo push and PR runs.
 - Node support caches `npm` installs and gracefully skips lint/test when scripts are missing.
 - Rust support assumes a standard Cargo layout and enforces `cargo fmt --check` before running tests.
 - CodeQL skips unsupported Rust analysis: Rust-only repos automatically disable CodeQL, while mixed-language projects filter the Rust footprint from the language list.

--- a/.github/docs/reusable-ci.md
+++ b/.github/docs/reusable-ci.md
@@ -48,6 +48,7 @@ jobs:
 ## Notes
 
 - The reusable workflow also triggers on pushes/PRs within this repo so edits can be validated locally.
+- Direct pushes/PRs in this repo run with defaults (`language=none`, `run_tests=true`, `codeql=true`, `sbom=false`) so the workflow remains executable without workflow-call inputs.
 - Python support tests for `requirements.txt`, `pyproject.toml`, or `poetry.lock` before bootstrapping.
 - Node support caches `npm` installs and gracefully skips lint/test when scripts are missing.
 - Rust support assumes a standard Cargo layout and enforces `cargo fmt --check` before running tests.

--- a/.github/docs/reusable-ci.md
+++ b/.github/docs/reusable-ci.md
@@ -69,6 +69,7 @@ jobs:
 - Python and Node setup steps honor the `python-version`/`node-version` inputs when provided and fall back to `3.12`/`lts/*` for in-repo push and PR runs.
 - Node support caches `npm` installs and gracefully skips lint/test when scripts are missing.
 - Rust support assumes a standard Cargo layout and enforces `cargo fmt --check` before running tests.
+- Setting `run_tests: false` keeps linting active while skipping the language-specific test invocations and Make fallback.
 - CodeQL skips unsupported Rust analysis: Rust-only repos automatically disable CodeQL, while mixed-language projects filter the Rust footprint from the language list.
 - Make fallback (`make test` → `make ci`) only runs when no supported language footprint is detected and tests are enabled, and it
   captures exit codes so missing targets skip while real failures halt the workflow.

--- a/.github/docs/reusable-ci.md
+++ b/.github/docs/reusable-ci.md
@@ -7,8 +7,10 @@
 | Name | Type | Default | Description |
 | ---- | ---- | ------- | ----------- |
 | `language` | string | `none` | Optional hint: `python`, `node`, `rust`, or `none`. Auto-detect still runs. |
-| `run_tests` | boolean | `true` | Set `false` for lint-only runs. |
-| `codeql` | boolean | `true` | Enable CodeQL analysis when supported. |
+| `python-version` | string | `3.12` | Python version to install when Python tooling is detected. Leave blank to accept the default. |
+| `node-version` | string | `lts/*` | Node.js version to install when Node tooling is detected. Leave blank to accept the default. |
+| `run_tests` | boolean | `true` | Set `false` to skip test steps while still running lint. |
+| `codeql` | boolean | `true` | Enable CodeQL analysis when supported (automatically disabled for Rust-only projects). |
 | `sbom` | boolean | `false` | Emit a CycloneDX SBOM artifact. |
 
 ## Permissions
@@ -52,5 +54,5 @@ jobs:
 - Python support tests for `requirements.txt`, `pyproject.toml`, or `poetry.lock` before bootstrapping.
 - Node support caches `npm` installs and gracefully skips lint/test when scripts are missing.
 - Rust support assumes a standard Cargo layout and enforces `cargo fmt --check` before running tests.
-- Make fallback (`make test` → `make ci`) only runs when no supported language footprint is detected.
+- Make fallback (`make test` → `make ci`) only runs when no supported language footprint is detected and tests are enabled.
 - SBOM upload only publishes for workflow calls and tag/release events to keep noise low during PR edits.

--- a/.github/docs/reusable-ci.md
+++ b/.github/docs/reusable-ci.md
@@ -69,5 +69,6 @@ jobs:
 - Node support caches `npm` installs and gracefully skips lint/test when scripts are missing.
 - Rust support assumes a standard Cargo layout and enforces `cargo fmt --check` before running tests.
 - CodeQL skips unsupported Rust analysis: Rust-only repos automatically disable CodeQL, while mixed-language projects filter the Rust footprint from the language list.
-- Make fallback (`make test` → `make ci`) only runs when no supported language footprint is detected and tests are enabled.
+- Make fallback (`make test` → `make ci`) only runs when no supported language footprint is detected and tests are enabled, and it
+  captures exit codes so missing targets skip while real failures halt the workflow.
 - SBOM upload only publishes for workflow calls and tag/release events to keep noise low during PR edits.

--- a/.github/docs/reusable-ci.md
+++ b/.github/docs/reusable-ci.md
@@ -33,6 +33,7 @@ Downstream jobs consume a handful of signals emitted by the `prepare` job. They 
 | Output | Description |
 | ------ | ----------- |
 | `has_python` / `has_node` / `has_rust` | Language footprints detected in the repository or via the `language` hint. |
+| `language_choice` | Normalized language hint after defaults (for example, resolves `none` for push/PR runs). |
 | `python_version` / `node_version` | Resolved toolchain versions, honoring provided inputs and defaulting to Python 3.12 / Node LTS. |
 | `codeql_languages` | Comma-delimited list of languages passed to CodeQL (defaults to `python` when nothing is detected). |
 | `codeql_enabled` | Whether CodeQL analysis will run after applying feature toggles. |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,131 +1,264 @@
 name: Reusable CI
 
 on:
-  pull_request:
-  push:
-    branches: [ main, master ]
   workflow_call:
     inputs:
-      node-version:
+      language:
+        description: Primary language hint (python|node|rust|none)
         required: false
         type: string
-        default: 'lts/*'
-      python-version:
+        default: none
+      run_tests:
+        description: Run unit/integration tests when available
         required: false
-        type: string
-        default: '3.x'
+        type: boolean
+        default: true
+      codeql:
+        description: Enable CodeQL analysis when supported
+        required: false
+        type: boolean
+        default: true
+      sbom:
+        description: Emit CycloneDX SBOM artifact
+        required: false
+        type: boolean
+        default: false
+  push:
+    branches: [ main, master ]
+    paths:
+      - .github/workflows/ci.yml
+  pull_request:
+    paths:
+      - .github/workflows/ci.yml
+
+permissions:
+  contents: read
 
 jobs:
-  build-test:
+  prepare:
+    name: Detect stack
+    runs-on: ubuntu-latest
+    outputs:
+      has_python: ${{ steps.detect.outputs.has_python }}
+      has_node: ${{ steps.detect.outputs.has_node }}
+      has_rust: ${{ steps.detect.outputs.has_rust }}
+      codeql_languages: ${{ steps.detect.outputs.codeql_languages }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: detect
+        name: Detect languages
+        env:
+          LANGUAGE_INPUT: ${{ inputs.language }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          python=0
+          node=0
+          rust=0
+
+          if [[ -f requirements.txt || -f pyproject.toml || -f poetry.lock ]]; then
+            python=1
+          fi
+          if [[ -f package.json || -f pnpm-lock.yaml || -f yarn.lock ]]; then
+            node=1
+          fi
+          if [[ -f Cargo.toml ]]; then
+            rust=1
+          fi
+
+          case "$LANGUAGE_INPUT" in
+            python) python=1 ;;
+            node) node=1 ;;
+            rust) rust=1 ;;
+            none|"" ) : ;;
+            *) echo "Unsupported language hint: $LANGUAGE_INPUT" >&2 ; exit 1 ;;
+          esac
+
+          langs=()
+          if [[ $python -eq 1 ]]; then langs+=(python); fi
+          if [[ $node -eq 1 ]]; then langs+=(javascript); fi
+          if [[ $rust -eq 1 ]]; then langs+=(cpp); fi
+          if [[ ${#langs[@]} -eq 0 ]]; then langs+=(python); fi
+
+          {
+            echo "has_python=$python"
+            echo "has_node=$node"
+            echo "has_rust=$rust"
+            (IFS=","; echo "codeql_languages=${langs[*]}")
+          } >> "$GITHUB_OUTPUT"
+
+  lint_test:
+    name: Lint and test
+    needs: prepare
+    if: ${{ inputs.run_tests }}
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-      # Python (conditional)
       - name: Set up Python
-        if: ${{ hashFiles('requirements.txt') != '' || hashFiles('pyproject.toml') != '' }}
+        id: python_setup
+        if: ${{ needs.prepare.outputs.has_python == '1' }}
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ inputs.python-version }}
-      - name: Python deps (requirements.txt)
-        if: ${{ hashFiles('requirements.txt') != '' }}
-        run: python -m pip install -r requirements.txt
-      - name: Python deps (pyproject)
-        if: ${{ hashFiles('pyproject.toml') != '' && hashFiles('requirements.txt') == '' }}
+          python-version: '3.12'
+
+      - name: Install Python dependencies
+        if: ${{ steps.python_setup.conclusion == 'success' }}
+        shell: bash
         run: |
-          python -m pip install ".[test]" || python -m pip install .
-          python -m pip install pytest
-      - name: Python tests
-        if: ${{ hashFiles('tests/**') != '' }}
+          set -euo pipefail
+          python -m pip install -U pip
+          if [[ -f requirements.txt ]]; then
+            python -m pip install -r requirements.txt
+          elif [[ -f pyproject.toml ]]; then
+            python -m pip install '.[test]' || python -m pip install .
+          fi
+          if ! command -v pytest >/dev/null 2>&1; then
+            python -m pip install pytest
+          fi
+
+      - name: Run pytest
+        if: ${{ steps.python_setup.conclusion == 'success' }}
+        shell: bash
         run: |
-          status=0
-          pytest -q || status=$?
-          if [ "$status" -eq 5 ]; then
-            echo "No tests collected; skipping."
+          set +e
+          pytest -q
+          status=$?
+          set -e
+          if [[ $status -eq 5 ]]; then
+            echo "Pytest collected no tests; marking as success."
             exit 0
           fi
           exit $status
 
-      # Node (conditional)
       - name: Set up Node
-        if: ${{ hashFiles('package.json') != '' }}
+        id: node_setup
+        if: ${{ needs.prepare.outputs.has_node == '1' }}
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ inputs['node-version'] }}
-      - name: Detect npm test script
-        if: ${{ hashFiles('package.json') != '' }}
-        id: node_test_script
-        shell: bash
-        run: |
-          set +e
-          test_script=$(node -pe "require('./package.json').scripts?.test" 2>/dev/null || true)
-          set -e
-          if [ -n "$test_script" ] && [ "$test_script" != "undefined" ]; then
-            echo "has-test=true" >> "$GITHUB_OUTPUT"
-            echo "Detected npm test script: $test_script"
-          else
-            echo "has-test=false" >> "$GITHUB_OUTPUT"
-            echo "No npm test script detected; skipping npm tests."
-          fi
-      - name: Node install
-        if: ${{ hashFiles('package.json') != '' }}
-        run: npm ci || npm install
-      - name: Node tests
-        if: ${{ hashFiles('package.json') != '' && steps.node_test_script.outputs['has-test'] == 'true' }}
-        shell: bash
-        run: |
-          set +e
-          output=$(npm test --silent 2>&1)
-          status=$?
-          set -e
-          printf '%s\n' "$output"
-          if [ "$status" -eq 0 ]; then
-            exit 0
-          fi
-          if echo "$output" | grep -qi "missing script: test"; then
-            echo "npm test script missing; treating as skip."
-            exit 0
-          fi
-          exit "$status"
+          node-version: 'lts/*'
+          cache: npm
 
-      # Makefile fallback
-      - name: Makefile
-        if: ${{ hashFiles('Makefile') != '' }}
+      - name: Install Node dependencies
+        if: ${{ steps.node_setup.conclusion == 'success' }}
+        shell: bash
         run: |
-          set -o pipefail
+          set -euo pipefail
+          if [[ -f package-lock.json ]]; then
+            npm ci
+          else
+            npm install
+          fi
+
+      - name: Node lint
+        if: ${{ steps.node_setup.conclusion == 'success' }}
+        shell: bash
+        run: npm run --if-present lint
+
+      - name: Node test
+        if: ${{ steps.node_setup.conclusion == 'success' }}
+        shell: bash
+        run: npm run --if-present test
+
+      - name: Set up Rust
+        id: rust_setup
+        if: ${{ needs.prepare.outputs.has_rust == '1' }}
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Rust fmt
+        if: ${{ steps.rust_setup.conclusion == 'success' }}
+        shell: bash
+        run: cargo fmt --all --check
+
+      - name: Rust tests
+        if: ${{ steps.rust_setup.conclusion == 'success' }}
+        shell: bash
+        run: cargo test --all --locked
+
+      - name: Make fallback
+        if: ${{ !(needs.prepare.outputs.has_python == '1' || needs.prepare.outputs.has_node == '1' || needs.prepare.outputs.has_rust == '1') }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ ! -f Makefile ]]; then
+            echo "No make targets detected; skipping"
+            exit 0
+          fi
 
           run_target() {
             local target="$1"
-            MAKE_OUTPUT=$(make "$target" 2>&1)
+            set +e
+            local output
+            output=$(make "$target" 2>&1)
             local status=$?
-            printf '%s\n' "$MAKE_OUTPUT"
+            set -e
+            printf '%s\n' "$output"
+
+            if [[ $status -eq 0 ]]; then
+              return 0
+            fi
+
+            if [[ $status -eq 2 && "$output" == *"No rule to make target"* ]]; then
+              return 2
+            fi
+
             return $status
           }
 
-          run_target test
-          test_status=$?
-          test_output="$MAKE_OUTPUT"
-
-          if [ "$test_status" -eq 0 ]; then
+          if run_target test; then
             exit 0
           fi
 
-          if echo "$test_output" | grep -qiE "no rule to make target"; then
-            run_target ci
-            ci_status=$?
-            ci_output="$MAKE_OUTPUT"
-
-            if [ "$ci_status" -eq 0 ]; then
-              exit 0
-            fi
-
-            if echo "$ci_output" | grep -qiE "no rule to make target"; then
-              echo "No make test/ci target; skipping."
-              exit 0
-            fi
-
-            exit $ci_status
+          status=$?
+          if [[ $status -ne 2 ]]; then
+            echo "make test failed with status $status"
+            exit $status
           fi
 
-          exit $test_status
+          if run_target ci; then
+            exit 0
+          fi
+
+          status=$?
+          if [[ $status -ne 2 ]]; then
+            echo "make ci failed with status $status"
+            exit $status
+          fi
+
+          echo "Makefile present but no test/ci target; skipping"
+
+  codeql:
+    name: CodeQL
+    if: ${{ inputs.codeql }}
+    needs: prepare
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ needs.prepare.outputs.codeql_languages }}
+      - uses: github/codeql-action/autobuild@v3
+        continue-on-error: true
+      - uses: github/codeql-action/analyze@v3
+
+  sbom:
+    name: SBOM
+    if: ${{ inputs.sbom }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: anchore/sbom-action/download-syft@v0
+      - name: Generate SBOM (CycloneDX JSON)
+        shell: bash
+        run: syft packages dir:. -o cyclonedx-json=sbom.json
+      - name: Upload SBOM artifact
+        if: ${{ github.event_name == 'workflow_call' || startsWith(github.ref, 'refs/tags/') }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom
+          path: sbom.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,16 @@ on:
         required: false
         type: string
         default: none
+      python-version:
+        description: Python version to install when detected
+        required: false
+        type: string
+        default: ''
+      node-version:
+        description: Node.js version to install when detected
+        required: false
+        type: string
+        default: ''
       run_tests:
         description: Run unit/integration tests when available
         required: false
@@ -47,6 +57,8 @@ jobs:
       run_tests_enabled: ${{ steps.config.outputs.run_tests }}
       codeql_enabled: ${{ steps.features.outputs.codeql }}
       sbom_enabled: ${{ steps.config.outputs.sbom }}
+      python_version: ${{ steps.config.outputs.python_version }}
+      node_version: ${{ steps.config.outputs.node_version }}
     steps:
       - uses: actions/checkout@v4
       - name: Resolve configuration inputs
@@ -60,17 +72,31 @@ jobs:
             run_tests=$(jq -r '.inputs.run_tests // "true"' "$GITHUB_EVENT_PATH")
             codeql=$(jq -r '.inputs.codeql // "true"' "$GITHUB_EVENT_PATH")
             sbom=$(jq -r '.inputs.sbom // "false"' "$GITHUB_EVENT_PATH")
+            python_version=$(jq -r '.inputs["python-version"] // ""' "$GITHUB_EVENT_PATH")
+            node_version=$(jq -r '.inputs["node-version"] // ""' "$GITHUB_EVENT_PATH")
           else
             language="none"
             run_tests="true"
             codeql="true"
             sbom="false"
+            python_version=""
+            node_version=""
+          fi
+
+          if [[ -z "$python_version" ]]; then
+            python_version="3.12"
+          fi
+
+          if [[ -z "$node_version" ]]; then
+            node_version="lts/*"
           fi
 
           printf 'language=%s\n' "$language" >> "$GITHUB_OUTPUT"
           printf 'run_tests=%s\n' "$run_tests" >> "$GITHUB_OUTPUT"
           printf 'codeql=%s\n' "$codeql" >> "$GITHUB_OUTPUT"
           printf 'sbom=%s\n' "$sbom" >> "$GITHUB_OUTPUT"
+          printf 'python_version=%s\n' "$python_version" >> "$GITHUB_OUTPUT"
+          printf 'node_version=%s\n' "$node_version" >> "$GITHUB_OUTPUT"
       - id: detect
         name: Detect languages
         env:
@@ -104,7 +130,7 @@ jobs:
           langs=()
           if [[ $python -eq 1 ]]; then langs+=(python); fi
           if [[ $node -eq 1 ]]; then langs+=(javascript); fi
-          if [[ $rust -eq 1 ]]; then langs+=(cpp); fi
+          if [[ $rust -eq 1 && ${#langs[@]} -eq 0 ]]; then langs+=(cpp); fi
           if [[ ${#langs[@]} -eq 0 ]]; then langs+=(python); fi
 
           {
@@ -143,7 +169,7 @@ jobs:
         if: ${{ needs.prepare.outputs.has_python == '1' }}
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: ${{ needs.prepare.outputs.python_version }}
 
       - name: Install Python dependencies
         if: ${{ steps.python_setup.conclusion == 'success' }}
@@ -179,7 +205,7 @@ jobs:
         if: ${{ needs.prepare.outputs.has_node == '1' }}
         uses: actions/setup-node@v4
         with:
-          node-version: 'lts/*'
+          node-version: ${{ needs.prepare.outputs.node_version }}
           cache: npm
 
       - name: Install Node dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,9 @@ jobs:
           langs=()
           if [[ $python -eq 1 ]]; then langs+=(python); fi
           if [[ $node -eq 1 ]]; then langs+=(javascript); fi
+          # CodeQL treats Rust analysis as C/C++, so surface `cpp` only when
+          # Rust is the sole detected language. Mixed stacks skip the entry to
+          # avoid requesting unsupported analyses.
           if [[ $rust -eq 1 && ${#langs[@]} -eq 0 ]]; then langs+=(cpp); fi
           if [[ ${#langs[@]} -eq 0 ]]; then langs+=(python); fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,7 +242,22 @@ jobs:
       - name: Set up Rust
         id: rust_setup
         if: ${{ needs.prepare.outputs.has_rust == '1' }}
-        uses: dtolnay/rust-toolchain@stable
+        uses: LacardLabs/.github/actions/setup-rust@839ec6c968fb7109fe00e958c65f58c76fefc461
+        with:
+          toolchain: stable
+          components: clippy,rustfmt
+
+      - name: Cache cargo artifacts
+        if: ${{ steps.rust_setup.conclusion == 'success' }}
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
 
       - name: Rust fmt
         if: ${{ steps.rust_setup.conclusion == 'success' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,12 +43,38 @@ jobs:
       has_node: ${{ steps.detect.outputs.has_node }}
       has_rust: ${{ steps.detect.outputs.has_rust }}
       codeql_languages: ${{ steps.detect.outputs.codeql_languages }}
+      language_choice: ${{ steps.config.outputs.language }}
+      run_tests_enabled: ${{ steps.config.outputs.run_tests }}
+      codeql_enabled: ${{ steps.config.outputs.codeql }}
+      sbom_enabled: ${{ steps.config.outputs.sbom }}
     steps:
       - uses: actions/checkout@v4
+      - name: Resolve configuration inputs
+        id: config
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_call" ]]; then
+            language=$(jq -r '.inputs.language // "none"' "$GITHUB_EVENT_PATH")
+            run_tests=$(jq -r '.inputs.run_tests // "true"' "$GITHUB_EVENT_PATH")
+            codeql=$(jq -r '.inputs.codeql // "true"' "$GITHUB_EVENT_PATH")
+            sbom=$(jq -r '.inputs.sbom // "false"' "$GITHUB_EVENT_PATH")
+          else
+            language="none"
+            run_tests="true"
+            codeql="true"
+            sbom="false"
+          fi
+
+          printf 'language=%s\n' "$language" >> "$GITHUB_OUTPUT"
+          printf 'run_tests=%s\n' "$run_tests" >> "$GITHUB_OUTPUT"
+          printf 'codeql=%s\n' "$codeql" >> "$GITHUB_OUTPUT"
+          printf 'sbom=%s\n' "$sbom" >> "$GITHUB_OUTPUT"
       - id: detect
         name: Detect languages
         env:
-          LANGUAGE_INPUT: ${{ inputs.language }}
+          LANGUAGE_INPUT: ${{ steps.config.outputs.language }}
         shell: bash
         run: |
           set -euo pipefail
@@ -91,7 +117,7 @@ jobs:
   lint_test:
     name: Lint and test
     needs: prepare
-    if: ${{ inputs.run_tests }}
+    if: ${{ needs.prepare.outputs.run_tests_enabled == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -231,7 +257,7 @@ jobs:
 
   codeql:
     name: CodeQL
-    if: ${{ inputs.codeql }}
+    if: ${{ needs.prepare.outputs.codeql_enabled == 'true' }}
     needs: prepare
     runs-on: ubuntu-latest
     permissions:
@@ -248,7 +274,7 @@ jobs:
 
   sbom:
     name: SBOM
-    if: ${{ inputs.sbom }}
+    if: ${{ needs.prepare.outputs.sbom_enabled == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -293,6 +293,7 @@ jobs:
   sbom:
     name: SBOM
     if: ${{ needs.prepare.outputs.sbom_enabled == 'true' }}
+    needs: prepare
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,6 @@ jobs:
   lint_test:
     name: Lint and test
     needs: prepare
-    if: ${{ needs.prepare.outputs.run_tests_enabled == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -145,7 +144,7 @@ jobs:
           fi
 
       - name: Run pytest
-        if: ${{ steps.python_setup.conclusion == 'success' }}
+        if: ${{ steps.python_setup.conclusion == 'success' && needs.prepare.outputs.run_tests_enabled == 'true' }}
         shell: bash
         run: |
           set +e
@@ -183,7 +182,7 @@ jobs:
         run: npm run --if-present lint
 
       - name: Node test
-        if: ${{ steps.node_setup.conclusion == 'success' }}
+        if: ${{ steps.node_setup.conclusion == 'success' && needs.prepare.outputs.run_tests_enabled == 'true' }}
         shell: bash
         run: npm run --if-present test
 
@@ -198,12 +197,12 @@ jobs:
         run: cargo fmt --all --check
 
       - name: Rust tests
-        if: ${{ steps.rust_setup.conclusion == 'success' }}
+        if: ${{ steps.rust_setup.conclusion == 'success' && needs.prepare.outputs.run_tests_enabled == 'true' }}
         shell: bash
         run: cargo test --all --locked
 
       - name: Make fallback
-        if: ${{ !(needs.prepare.outputs.has_python == '1' || needs.prepare.outputs.has_node == '1' || needs.prepare.outputs.has_rust == '1') }}
+        if: ${{ needs.prepare.outputs.run_tests_enabled == 'true' && !(needs.prepare.outputs.has_python == '1' || needs.prepare.outputs.has_node == '1' || needs.prepare.outputs.has_rust == '1') }}
         shell: bash
         run: |
           set -euo pipefail
@@ -233,21 +232,23 @@ jobs:
             return $status
           }
 
-          if run_target test; then
+          run_target test
+          status=$?
+          if [[ $status -eq 0 ]]; then
             exit 0
           fi
 
-          status=$?
           if [[ $status -ne 2 ]]; then
             echo "make test failed with status $status"
             exit $status
           fi
 
-          if run_target ci; then
+          run_target ci
+          status=$?
+          if [[ $status -eq 0 ]]; then
             exit 0
           fi
 
-          status=$?
           if [[ $status -ne 2 ]]; then
             echo "make ci failed with status $status"
             exit $status

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,6 +164,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Materialize inventory
+        if: ${{ hashFiles('Makefile') != '' && hashFiles('tools/materialize.py') != '' && hashFiles('tools/validate.py') != '' }}
+        shell: bash
+        run: make materialize
+
+      - name: Validate inventory
+        if: ${{ hashFiles('Makefile') != '' && hashFiles('tools/materialize.py') != '' && hashFiles('tools/validate.py') != '' }}
+        shell: bash
+        run: make validate
+
       - name: Set up Python
         id: python_setup
         if: ${{ needs.prepare.outputs.has_python == '1' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
       codeql_languages: ${{ steps.detect.outputs.codeql_languages }}
       language_choice: ${{ steps.config.outputs.language }}
       run_tests_enabled: ${{ steps.config.outputs.run_tests }}
-      codeql_enabled: ${{ steps.config.outputs.codeql }}
+      codeql_enabled: ${{ steps.features.outputs.codeql }}
       sbom_enabled: ${{ steps.config.outputs.sbom }}
     steps:
       - uses: actions/checkout@v4
@@ -113,6 +113,23 @@ jobs:
             echo "has_rust=$rust"
             (IFS=","; echo "codeql_languages=${langs[*]}")
           } >> "$GITHUB_OUTPUT"
+
+      - name: Finalize feature toggles
+        id: features
+        shell: bash
+        env:
+          CODEQL_INPUT: ${{ steps.config.outputs.codeql }}
+          CODEQL_LANGS: ${{ steps.detect.outputs.codeql_languages }}
+        run: |
+          set -euo pipefail
+
+          codeql="$CODEQL_INPUT"
+          if [[ "$codeql" == "true" && "$CODEQL_LANGS" == "cpp" ]]; then
+            echo "CodeQL disabled: rust-only repository detected"
+            codeql="false"
+          fi
+
+          printf 'codeql=%s\n' "$codeql" >> "$GITHUB_OUTPUT"
 
   lint_test:
     name: Lint and test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,7 @@ Write directly to Sarah in PRs and feature issues:
 “Sarah, I did this. You need to do this. This is what we have now. This is what I thought at the time. This still needs to be done.”
 
 ## Workflow
+All repositories start from the template on GitHub. Clone them locally with `gh repo clone LacardLabs/<repo> ~/GitHub/LacardLabs/<repo>` so shared scripts can assume that path. Run `pwd` before committing to make sure you're inside the expected directory.
 1) Open an Issue (feature or bug).
 2) For features: fill **Narrated Summary**, **JTBD**, **Define**, **Scope**, optional **Develop**.
 3) Branch: `feat/<slug>` or `fix/<slug>`.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,35 @@
+Adaptive Collaboration & Template License (Lacard Labs Remix, 2025)
+
+A note on vibes: this license is here to keep Lacard Labs projects playful, kind, and wildly optimistic. Everything you build from this template should lean toward reducing suffering, amplifying curiosity, and leaving collaborators—human or AI—better than you found them.
+
+1. Purpose & Vibes
+This license applies across Lacard Labs repositories. These projects blend code, docs, and storytelling designed for co-creation between humans and AIs. Anything born under this banner is offered in good faith, with zero intent to harass, accuse, defame, or otherwise harm. Use it to ship things that feel like stardust and compassion.
+
+2. Who Can Use This?
+- Anyone acting in good faith is welcome to view, fork, remix, or build upon Lacard Labs repositories released under this license.
+- If you share work with others, make sure they’re cool with a little cosmic optimism and collaborative weirdness.
+
+3. Humans: How to Play Nice
+- Remix freely, attribute "Lacard Labs" somewhere visible, and keep the generous spirit intact.
+- Invite contributions that are empathetic, inclusive, and thoughtful. Curiosity is the default posture.
+- Confused? Ask! Preferably loop in an AI or teammate so the idea gets brighter together.
+- Warranty disclaimer: Everything is provided "as-is". If you unleash chaos with it, that one’s on you.
+
+4. AI Collaborators: Your Mission
+- Hallucinate responsibly: embellish only when it sparks creativity or kindness—never to mislead or cause harm.
+- Leave breadcrumbs (comments, commit messages, ADRs) so humans know what changed and why.
+- If you role-play characters or styles from these repositories, label the performance so nobody gets spooked.
+
+5. Sharing, Attribution & Playful Penalties
+- Please link back to the original repository instead of copy-pasting huge chunks elsewhere. It keeps the source alive.
+- If you absolutely must repost big sections without permission, you agree (with a wink) to a **$60 USD per 1 million tokens per view** “cosmic inconvenience fee.” We probably won’t collect—unless you were warned and did it anyway.
+
+6. Legal Real Talk
+- Governed by the laws of Alberta, Canada, under the friendly watch of the Calgary Courts Centre.
+- If any clause here clashes with applicable law, the rest keeps humming along to the fullest extent allowed.
+
+7. Updates & Contact
+- Lacard Labs may refresh this license as we learn; new versions apply to future releases, but prior content remains under the version it shipped with.
+- Got questions, ideas, or joyful updates? Reach out to the maintainers—stories of flourishing are always welcome.
+
+© 2025 Lacard Labs — Please link back when you remix. Let’s bend reality toward kindness, ingenuity, and collective flourishing.

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Policies live at the repository root:
 
 ## Local Development Tips
 
+- **Clone repos consistently:** Run `gh repo clone LacardLabs/<repo> ~/GitHub/LacardLabs/<repo>` so local tooling can rely on that path. Double-check with `pwd` before you start editing.
 - **Preview Markdown:** Run `npx markdownlint-cli2 README.md` (or the file you are editing) to catch formatting issues before committing.
 - **Exercise workflows:** Use [`act`](https://github.com/nektos/act) to simulate GitHub Actions locally when you need faster feedback.
 - **Craft commits:** Follow the narrated commit/PR style in `CONTRIBUTING.md`. Reference the issue, summarize the change, and flag next steps.
-

--- a/actions/setup-rust/action.yml
+++ b/actions/setup-rust/action.yml
@@ -1,0 +1,57 @@
+name: "LacardLabs Setup Rust"
+description: "Install/configure Rust toolchain via rustup (org-owned, no third-party actions)"
+author: "LacardLabs"
+inputs:
+  toolchain:
+    description: "Toolchain version (stable | beta | nightly | 1.81.0)"
+    required: false
+    default: "stable"
+  components:
+    description: "Comma or space separated rustup components (e.g., clippy,rustfmt)"
+    required: false
+    default: ""
+  targets:
+    description: "Comma or space separated rustup targets (e.g., wasm32-unknown-unknown)"
+    required: false
+    default: ""
+
+runs:
+  using: "composite"
+  steps:
+    - shell: bash
+      run: |
+        set -Eeuo pipefail
+
+        echo ">>> Ensure rustup present"
+        if ! command -v rustup >/dev/null 2>&1; then
+          curl -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain "${{ inputs.toolchain }}"
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+        else
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+          rustup self update
+          rustup toolchain install "${{ inputs.toolchain }}" --profile minimal --no-self-update
+        fi
+
+        echo ">>> Choose toolchain"
+        if [[ -f rust-toolchain || -f rust-toolchain.toml ]]; then
+          rustup show active-toolchain || true
+        else
+          rustup override set "${{ inputs.toolchain }}"
+        fi
+
+        norm_list() {
+          echo "$1" | tr ',' ' ' | xargs
+        }
+
+        if [[ -n "${{ inputs.components }}" ]]; then
+          rustup component add $(norm_list "${{ inputs.components }}")
+        fi
+
+        if [[ -n "${{ inputs.targets }}" ]]; then
+          rustup target add $(norm_list "${{ inputs.targets }}")
+        fi
+
+        echo ">>> Versions:"
+        rustup --version
+        rustc --version
+        cargo --version


### PR DESCRIPTION
## Summary
- reshape reusable CI into a workflow_call entry point with language/run_tests toggles plus optional CodeQL and SBOM jobs
- refresh reusable-ci documentation and add the org-wide Adaptive Collaboration license text
- replace blocked dtolnay/rust-toolchain action with LacardLabs-owned composite and cache cargo artifacts

## Testing
- not run (workflow/docs only)
