### PR TITLE
ci: use GITHUB_TOKEN for org settings PRs

### DIFF
--- a/.github/workflows/org-settings-report.yml
+++ b/.github/workflows/org-settings-report.yml
@@ -22,14 +22,16 @@ jobs:
         uses: actions/checkout@v4
       - name: Export org settings
         if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
-        # ORG_REPORT_TOKEN must be scoped for read:org and admin:org so gh api calls succeed.
+        # ORG_REPORT_TOKEN must include read:org and admin:org scopes for the export script's gh api calls.
         env:
           GH_TOKEN: ${{ secrets.ORG_REPORT_TOKEN }}
         run: python3 scripts/export_org_settings.py
       - name: Create pull request when changes detected
         if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
         env:
-          GH_TOKEN: ${{ secrets.ORG_REPORT_TOKEN }}
+          # Use the workflow's GITHUB_TOKEN for PR creation (pull-requests: write).
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GIT_AUTHOR_NAME: github-actions[bot]
           GIT_AUTHOR_EMAIL: github-actions[bot]@users.noreply.github.com
         run: |


### PR DESCRIPTION
## Summary
- use the workflow-provided token for PR creation so we no longer require a repo-scoped PAT
- keep the org report export using ORG_REPORT_TOKEN for gh api calls and clarify the scope note

## Testing
- workflow_dispatch (upcoming)