### PR TITLE
ci: grant actions read to codeql job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,6 +344,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      actions: read
       security-events: write
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Fix CodeQL uploads which were failing with 'Resource not accessible by integration'. Adds required actions:read permission.