### PR TITLE
ci: forward inputs as env vars

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,13 @@ jobs:
       - uses: actions/checkout@v4
       - name: Resolve configuration inputs
         id: config
+        env:
+          INPUT_LANGUAGE: ${{ inputs.language }}
+          INPUT_RUN_TESTS: ${{ inputs.run_tests }}
+          INPUT_CODEQL: ${{ inputs.codeql }}
+          INPUT_SBOM: ${{ inputs.sbom }}
+          INPUT_PYTHON_VERSION: ${{ inputs['python-version'] }}
+          INPUT_NODE_VERSION: ${{ inputs['node-version'] }}
         shell: bash
         run: |
           set -euo pipefail


### PR DESCRIPTION
Ensure reusable CI passes workflow inputs through env so shell steps see codeql=false when invoked from pull_request workflows.